### PR TITLE
MMMosaic bug fix

### DIFF
--- a/easycv/datasets/detection/pipelines/mm_transforms.py
+++ b/easycv/datasets/detection/pipelines/mm_transforms.py
@@ -244,7 +244,7 @@ class MMMosaic(object):
             x1, y1, x2, y2 = max(center_position_xy[0] - img_shape_wh[0], 0), \
                 center_position_xy[1], \
                 center_position_xy[0], \
-                min(self.img_scale[1] * 2, center_position_xy[1] +
+                min(self.img_scale[0] * 2, center_position_xy[1] +
                     img_shape_wh[1])
             crop_coord = img_shape_wh[0] - (x2 - x1), 0, img_shape_wh[0], min(
                 y2 - y1, img_shape_wh[1])


### PR DESCRIPTION
Fix index of image_scale with y2 with bottom_left implemented in _mosaic_combine


# Motivation
 MMMosaic bug fix

```
Original Traceback (most recent call last):
  File "/opt/conda/lib/python3.9/site-packages/torch/utils/data/_utils/worker.py", line 302, in _worker_loop
    data = fetcher.fetch(index)
  File "/opt/conda/lib/python3.9/site-packages/torch/utils/data/_utils/fetch.py", line 49, in fetch
    data = [self.dataset[idx] for idx in possibly_batched_index]
  File "/opt/conda/lib/python3.9/site-packages/torch/utils/data/_utils/fetch.py", line 49, in <listcomp>
    data = [self.dataset[idx] for idx in possibly_batched_index]
  File "/home/ubuntu/zrn_road_sign_detection_experiments/EasyCV/package/easycv/datasets/detection/mix.py", line 107, in __getitem__
    results = transform(results)
  File "/home/ubuntu/zrn_road_sign_detection_experiments/EasyCV/package/easycv/datasets/detection/pipelines/mm_transforms.py", line 109, in __call__
    results = self._mosaic_transform(results)
  File "/home/ubuntu/zrn_road_sign_detection_experiments/EasyCV/package/easycv/datasets/detection/pipelines/mm_transforms.py", line 174, in _mosaic_transform
    mosaic_img[y1_p:y2_p, x1_p:x2_p] = img_i[y1_c:y2_c, x1_c:x2_c]
ValueError: could not broadcast input array from shape (1333,1819,3) into shape (1291,1819,3)
```

# Modification
Fixed image_scale index from 1 to 0

