### PR TITLE
Modify check base cfg path

### DIFF
--- a/easycv/utils/config_tools.py
+++ b/easycv/utils/config_tools.py
@@ -3,6 +3,7 @@ import os.path as osp
 import platform
 import sys
 import tempfile
+import warnings
 from importlib import import_module
 
 from mmcv import Config, import_modules_from_strings
@@ -138,9 +139,11 @@ def check_base_cfg_path(base_cfg_name='configs/base.py',
                 break
         base_cfg_name = '/'.join(parse_ori_path_list + parse_base_path_list)
     else:
-        if not osp.exists(base_cfg_name):
-            if easycv_root is not None:
-                base_cfg_name = osp.join(easycv_root, base_cfg_name)
+        if not osp.exists(base_cfg_name) and osp.exists(
+                osp.join(easycv_root, base_cfg_name)):
+            base_cfg_name = osp.join(easycv_root, base_cfg_name)
+        else:
+            warnings.warn('base_cfg_name does not exist!')
 
     return base_cfg_name
 

--- a/easycv/utils/config_tools.py
+++ b/easycv/utils/config_tools.py
@@ -118,15 +118,9 @@ def check_base_cfg_path(base_cfg_name='configs/base.py',
                         father_cfg_name=None,
                         easycv_root=None):
     """
-    Concatenate paths by parsing path rules. Prioritize whether there is a cfg path locally.
-
-    for example(pseudo-code):
-        1. parse_base_cfg[0] == '.' or parse_base_cfg[0] == '..':
-            base_cfg_name = father_cfg_name + base_cfg_name
-
-        2. parse_base_cfg[0] != '.' and parse_base_cfg[0] != '..':
-            if not osp.exists(base_cfg_name):
-                base_cfg_name = easycv_root + base_cfg_name
+    Concatenate paths by parsing path rules.
+    If base_cfg_name is a relative path, it will be spliced with fater_cfg_name;
+    Otherwise, first judge whether base_cfg_name exists, if not, find it in easycv_root.
     """
     parse_base_cfg = base_cfg_name.split('/')
     if parse_base_cfg[0] == '.' or parse_base_cfg[0] == '..':

--- a/easycv/utils/config_tools.py
+++ b/easycv/utils/config_tools.py
@@ -119,7 +119,7 @@ def check_base_cfg_path(base_cfg_name='configs/base.py',
                         easycv_root=None):
     """
     Concatenate paths by parsing path rules.
-    If base_cfg_name is a relative path, it will be spliced with fater_cfg_name;
+    If base_cfg_name is a relative path, it will be spliced with father_cfg_name;
     Otherwise, first judge whether base_cfg_name exists, if not, find it in easycv_root.
     """
     parse_base_cfg = base_cfg_name.split('/')

--- a/tests/configs/test_check_base_cfg_path.py
+++ b/tests/configs/test_check_base_cfg_path.py
@@ -1,4 +1,7 @@
+import os
 import unittest
+
+from tests.ut_config import BASE_LOCAL_PATH
 
 from easycv.utils.config_tools import check_base_cfg_path
 
@@ -51,12 +54,12 @@ class CheckPathTest(unittest.TestCase):
             father_cfg_name=father_cfg_name,
             easycv_root=easycv_root)
 
-        self.assertEqual(
-            base_cfg_name,
-            'configs/classification/imagenet/resnet/common/base.py')
+        self.assertEqual(base_cfg_name, '/root/easycv/common/base.py')
 
     def test_check_4(self):
-        base_cfg_name = 'common/base.py'
+        base_cfg_name = os.path.join(
+            BASE_LOCAL_PATH,
+            'data/classification/imagenet/resnet/imagenet_resnet50_jpg.py')
         easycv_root = '/root/easycv'
         father_cfg_name = 'data/classification/imagenet/resnet/imagenet_resnet50_jpg.py'
         base_cfg_name = check_base_cfg_path(
@@ -64,19 +67,12 @@ class CheckPathTest(unittest.TestCase):
             father_cfg_name=father_cfg_name,
             easycv_root=easycv_root)
 
-        self.assertEqual(base_cfg_name,
-                         'data/classification/imagenet/resnet/common/base.py')
-
-    def test_check_5(self):
-        base_cfg_name = '../base.py'
-        easycv_root = '/root/easycv'
-        father_cfg_name = 'data/classification/imagenet/resnet/imagenet_resnet50_jpg.py'
-        base_cfg_name = check_base_cfg_path(
-            base_cfg_name=base_cfg_name,
-            father_cfg_name=father_cfg_name,
-            easycv_root=easycv_root)
-
-        self.assertEqual(base_cfg_name, 'data/classification/imagenet/base.py')
+        self.assertEqual(
+            base_cfg_name,
+            os.path.join(
+                BASE_LOCAL_PATH,
+                'data/classification/imagenet/resnet/imagenet_resnet50_jpg.py')
+        )
 
 
 if __name__ == '__main__':

--- a/tests/configs/test_check_base_cfg_path.py
+++ b/tests/configs/test_check_base_cfg_path.py
@@ -20,7 +20,7 @@ class CheckPathTest(unittest.TestCase):
             father_cfg_name=father_cfg_name,
             easycv_root=easycv_root)
 
-        self.assertEqual(base_cfg_name, '/root/easycv/configs/base.py')
+        self.assertEqual(base_cfg_name, 'configs/base.py')
 
     def test_check_1(self):
         base_cfg_name = 'benchmarks/base.py'

--- a/tests/ut_config.py
+++ b/tests/ut_config.py
@@ -30,7 +30,7 @@ NUSCENES_CLASSES = [
 ]
 
 BASE_OSS_PATH = 'oss://pai-vision-data-hz/unittest/'
-BASE_LOCAL_PATH = os.path.expanduser('~/easycv_nfs/')
+BASE_LOCAL_PATH = os.path.expanduser('/apsarapangu/disk4/easycv_nfs/')
 
 TMP_DIR_OSS = os.path.join(BASE_OSS_PATH, 'tmp')
 TMP_DIR_LOCAL = os.path.join(BASE_LOCAL_PATH, 'tmp')

--- a/tests/ut_config.py
+++ b/tests/ut_config.py
@@ -30,7 +30,7 @@ NUSCENES_CLASSES = [
 ]
 
 BASE_OSS_PATH = 'oss://pai-vision-data-hz/unittest/'
-BASE_LOCAL_PATH = os.path.expanduser('/apsarapangu/disk4/easycv_nfs/')
+BASE_LOCAL_PATH = os.path.expanduser('~/easycv_nfs/')
 
 TMP_DIR_OSS = os.path.join(BASE_OSS_PATH, 'tmp')
 TMP_DIR_LOCAL = os.path.join(BASE_LOCAL_PATH, 'tmp')


### PR DESCRIPTION
modify check_base_cfg_path.

If base_cfg_name is a relative path, it will be spliced with father_cfg_name;
Otherwise, first judge whether base_cfg_name exists, if not, find it in easycv_root.