### PR TITLE
Support multi processes for predictor

### DIFF
--- a/easycv/predictors/bevformer_predictor.py
+++ b/easycv/predictors/bevformer_predictor.py
@@ -27,7 +27,7 @@ class BEVFormerInputProcessor(InputProcessor):
         batch_size (int): batch size for forward.
         use_camera (bool): Whether use camera data.
         box_type_3d (str): Box type.
-        num_parallel (int): Number of processes to process inputs.
+        threads (int): Number of processes to process inputs.
     """
 
     def __init__(self,
@@ -37,16 +37,13 @@ class BEVFormerInputProcessor(InputProcessor):
                  use_camera=True,
                  box_type_3d='LiDAR',
                  adapt_jit=False,
-                 num_parallel=8):
+                 threads=8):
         self.use_camera = use_camera
         self.box_type_3d, self.box_mode_3d = get_box_type(box_type_3d)
         self.adapt_jit = adapt_jit
 
         super(BEVFormerInputProcessor, self).__init__(
-            cfg,
-            pipelines=pipelines,
-            batch_size=batch_size,
-            num_parallel=num_parallel)
+            cfg, pipelines=pipelines, batch_size=batch_size, threads=threads)
 
     def _prepare_input_dict(self, data_info):
         from nuscenes.eval.common.utils import Quaternion, quaternion_yaw
@@ -172,7 +169,7 @@ class BEVFormerPredictor(PredictorV2):
         box_type_3d (str): Box type.
         use_camera (bool): Whether use camera data.
         score_threshold (float): Score threshold to filter inference results.
-        num_parallel (int): Number of processes to process inputs.
+        input_processor_threads (int): Number of processes to process inputs.
         mode (str): The image mode into the model.
     """
 
@@ -188,7 +185,7 @@ class BEVFormerPredictor(PredictorV2):
                  use_camera=True,
                  score_threshold=0.1,
                  model_type=None,
-                 num_parallel=8,
+                 input_processor_threads=8,
                  mode='BGR',
                  *arg,
                  **kwargs):
@@ -217,7 +214,7 @@ class BEVFormerPredictor(PredictorV2):
             save_results=save_results,
             save_path=save_path,
             pipelines=pipelines,
-            num_parallel=num_parallel,
+            input_processor_threads=input_processor_threads,
             mode=mode,
             *arg,
             **kwargs)
@@ -245,7 +242,7 @@ class BEVFormerPredictor(PredictorV2):
             use_camera=self.use_camera,
             box_type_3d=self.box_type_3d_str,
             adapt_jit=self.is_jit_model,
-            num_parallel=self.num_parallel)
+            threads=self.input_processor_threads)
 
     def prepare_model(self):
         if self.is_jit_model:

--- a/easycv/predictors/classifier.py
+++ b/easycv/predictors/classifier.py
@@ -20,7 +20,7 @@ class ClsInputProcessor(InputProcessor):
         pipelines (list[dict]): Data pipeline configs.
         batch_size (int): batch size for forward.
         pil_input (bool): Whether use PIL image. If processor need PIL input, set true, default false.
-        num_parallel (int): Number of processes to process inputs.
+        threads (int): Number of processes to process inputs.
         mode (str): The image mode into the model.
     """
 
@@ -29,14 +29,11 @@ class ClsInputProcessor(InputProcessor):
                  pipelines=None,
                  batch_size=1,
                  pil_input=True,
-                 num_parallel=8,
+                 threads=8,
                  mode='BGR'):
 
         super(ClsInputProcessor, self).__init__(
-            cfg,
-            pipelines=pipelines,
-            batch_size=batch_size,
-            num_parallel=num_parallel)
+            cfg, pipelines=pipelines, batch_size=batch_size, threads=threads)
         self.mode = mode
         self.pil_input = pil_input
 
@@ -126,7 +123,7 @@ class ClassificationPredictor(PredictorV2):
         topk (int): Return top-k results. Default: 1.
         pil_input (bool): Whether use PIL image. If processor need PIL input, set true, default false.
         label_map_path (str): File path of saving labels list.
-        num_parallel (int): Number of processes to process inputs.
+        input_processor_threads (int): Number of processes to process inputs.
         mode (str): The image mode into the model.
     """
 
@@ -141,7 +138,7 @@ class ClassificationPredictor(PredictorV2):
                  topk=1,
                  pil_input=True,
                  label_map_path=None,
-                 num_parallel=8,
+                 input_processor_threads=8,
                  mode='BGR',
                  *args,
                  **kwargs):
@@ -159,7 +156,7 @@ class ClassificationPredictor(PredictorV2):
             save_results=save_results,
             save_path=save_path,
             pipelines=pipelines,
-            num_parallel=num_parallel,
+            input_processor_threads=input_processor_threads,
             mode=mode,
             *args,
             **kwargs)
@@ -169,7 +166,7 @@ class ClassificationPredictor(PredictorV2):
             self.cfg,
             pipelines=self.pipelines,
             batch_size=self.batch_size,
-            num_parallel=self.num_parallel,
+            threads=self.input_processor_threads,
             pil_input=self.pil_input,
             mode=self.mode)
 

--- a/easycv/predictors/classifier.py
+++ b/easycv/predictors/classifier.py
@@ -3,72 +3,42 @@ import math
 
 import numpy as np
 import torch
-from PIL import Image, ImageFile
+from PIL import Image
 
 from easycv.file import io
 from easycv.framework.errors import ValueError
 from easycv.utils.misc import deprecated
-from .base import Predictor, PredictorV2
+from .base import InputProcessor, OutputProcessor, Predictor, PredictorV2
 from .builder import PREDICTORS
 
 
-@PREDICTORS.register_module()
-class ClassificationPredictor(PredictorV2):
-    """Predictor for classification.
+class ClsInputProcessor(InputProcessor):
+    """Process inputs for classification models.
+
     Args:
-        model_path (str): Path of model path.
-        config_file (Optinal[str]): config file path for model and processor to init. Defaults to None.
-        batch_size (int): batch size for forward.
-        device (str): Support 'cuda' or 'cpu', if is None, detect device automatically.
-        save_results (bool): Whether to save predict results.
-        save_path (str): File path for saving results, only valid when `save_results` is True.
+        cfg (Config): Config instance.
         pipelines (list[dict]): Data pipeline configs.
-        topk (int): Return top-k results. Default: 1.
+        batch_size (int): batch size for forward.
         pil_input (bool): Whether use PIL image. If processor need PIL input, set true, default false.
-        label_map_path (str): File path of saving labels list.
+        num_parallel (int): Number of processes to process inputs.
+        mode (str): The image mode into the model.
     """
 
     def __init__(self,
-                 model_path,
-                 config_file=None,
-                 batch_size=1,
-                 device=None,
-                 save_results=False,
-                 save_path=None,
+                 cfg,
                  pipelines=None,
-                 topk=1,
+                 batch_size=1,
                  pil_input=True,
-                 label_map_path=None,
-                 *args,
-                 **kwargs):
-        super(ClassificationPredictor, self).__init__(
-            model_path,
-            config_file=config_file,
-            batch_size=batch_size,
-            device=device,
-            save_results=save_results,
-            save_path=save_path,
+                 num_parallel=8,
+                 mode='BGR'):
+
+        super(ClsInputProcessor, self).__init__(
+            cfg,
             pipelines=pipelines,
-            *args,
-            **kwargs)
-        self.topk = topk
+            batch_size=batch_size,
+            num_parallel=num_parallel)
+        self.mode = mode
         self.pil_input = pil_input
-
-        # Adapt to torchvision transforms which process PIL inputs.
-        if self.pil_input:
-            self.INPUT_IMAGE_MODE = 'RGB'
-
-        if label_map_path is None:
-            if 'CLASSES' in self.cfg:
-                class_list = self.cfg.get('CLASSES', [])
-            elif 'class_list' in self.cfg:
-                class_list = self.cfg.get('class_list', [])
-            else:
-                class_list = []
-        else:
-            with io.open(label_map_path, 'r') as f:
-                class_list = f.readlines()
-        self.label_map = [i.strip() for i in class_list]
 
     def _load_input(self, input):
         """Load image from file or numpy or PIL object.
@@ -86,8 +56,8 @@ class ClassificationPredictor(PredictorV2):
             results = {}
             if isinstance(input, str):
                 img = Image.open(input)
-                if img.mode.upper() != self.INPUT_IMAGE_MODE.upper():
-                    img = img.convert(self.INPUT_IMAGE_MODE.upper())
+                if img.mode.upper() != self.mode.upper():
+                    img = img.convert(self.mode.upper())
                 results['filename'] = input
             else:
                 if isinstance(input, np.ndarray):
@@ -103,7 +73,22 @@ class ClassificationPredictor(PredictorV2):
 
         return super()._load_input(input)
 
-    def postprocess(self, inputs, *args, **kwargs):
+
+class ClsOutputProcessor(OutputProcessor):
+    """Output processor for processing classification model outputs.
+
+    Args:
+        topk (int): Return top-k results. Default: 1.
+        label_map (dict): Dict of class id to class name.
+
+    """
+
+    def __init__(self, topk=1, label_map={}):
+        self.topk = topk
+        self.label_map = label_map
+        super(ClsOutputProcessor, self).__init__()
+
+    def __call__(self, inputs):
         """Return top-k results."""
         output_prob = inputs['prob'].data.cpu()
         topk_class = torch.topk(output_prob, self.topk).indices.numpy()
@@ -125,6 +110,84 @@ class ClassificationPredictor(PredictorV2):
 
             batch_results.append(result)
         return batch_results
+
+
+@PREDICTORS.register_module()
+class ClassificationPredictor(PredictorV2):
+    """Predictor for classification.
+    Args:
+        model_path (str): Path of model path.
+        config_file (Optinal[str]): config file path for model and processor to init. Defaults to None.
+        batch_size (int): batch size for forward.
+        device (str): Support 'cuda' or 'cpu', if is None, detect device automatically.
+        save_results (bool): Whether to save predict results.
+        save_path (str): File path for saving results, only valid when `save_results` is True.
+        pipelines (list[dict]): Data pipeline configs.
+        topk (int): Return top-k results. Default: 1.
+        pil_input (bool): Whether use PIL image. If processor need PIL input, set true, default false.
+        label_map_path (str): File path of saving labels list.
+        num_parallel (int): Number of processes to process inputs.
+        mode (str): The image mode into the model.
+    """
+
+    def __init__(self,
+                 model_path,
+                 config_file=None,
+                 batch_size=1,
+                 device=None,
+                 save_results=False,
+                 save_path=None,
+                 pipelines=None,
+                 topk=1,
+                 pil_input=True,
+                 label_map_path=None,
+                 num_parallel=8,
+                 mode='BGR',
+                 *args,
+                 **kwargs):
+        self.topk = topk
+        self.pil_input = pil_input
+        self.label_map_path = label_map_path
+
+        if self.pil_input:
+            mode = 'RGB'
+        super(ClassificationPredictor, self).__init__(
+            model_path,
+            config_file=config_file,
+            batch_size=batch_size,
+            device=device,
+            save_results=save_results,
+            save_path=save_path,
+            pipelines=pipelines,
+            num_parallel=num_parallel,
+            mode=mode,
+            *args,
+            **kwargs)
+
+    def get_input_processor(self):
+        return ClsInputProcessor(
+            self.cfg,
+            pipelines=self.pipelines,
+            batch_size=self.batch_size,
+            num_parallel=self.num_parallel,
+            pil_input=self.pil_input,
+            mode=self.mode)
+
+    def get_output_processor(self):
+        # Adapt to torchvision transforms which process PIL inputs.
+        if self.label_map_path is None:
+            if 'CLASSES' in self.cfg:
+                class_list = self.cfg.get('CLASSES', [])
+            elif 'class_list' in self.cfg:
+                class_list = self.cfg.get('class_list', [])
+            else:
+                class_list = []
+        else:
+            with io.open(self.label_map_path, 'r') as f:
+                class_list = f.readlines()
+        self.label_map = [i.strip() for i in class_list]
+
+        return ClsOutputProcessor(topk=self.topk, label_map=self.label_map)
 
 
 try:

--- a/easycv/predictors/face_keypoints_predictor.py
+++ b/easycv/predictors/face_keypoints_predictor.py
@@ -63,7 +63,7 @@ class FaceKeypointsPredictor(PredictorV2):
         save_results (bool): Whether to save predict results.
         save_path (str): File path for saving results, only valid when `save_results` is True.
         pipelines (list[dict]): Data pipeline configs.
-        num_parallel (int): Number of processes to process inputs.
+        input_processor_threads (int): Number of processes to process inputs.
         mode (str): The image mode into the model.
     """
 
@@ -76,7 +76,7 @@ class FaceKeypointsPredictor(PredictorV2):
         save_results=False,
         save_path=None,
         pipelines=None,
-        num_parallel=8,
+        input_processor_threads=8,
         mode='BGR',
     ):
         super(FaceKeypointsPredictor, self).__init__(
@@ -87,7 +87,7 @@ class FaceKeypointsPredictor(PredictorV2):
             save_results=save_results,
             save_path=save_path,
             pipelines=pipelines,
-            num_parallel=num_parallel,
+            input_processor_threads=input_processor_threads,
             mode=mode)
 
         self.input_size = self.cfg.IMAGE_SIZE

--- a/easycv/predictors/face_keypoints_predictor.py
+++ b/easycv/predictors/face_keypoints_predictor.py
@@ -3,7 +3,7 @@
 import cv2
 
 from easycv.predictors.builder import PREDICTORS
-from .base import PredictorV2
+from .base import OutputProcessor, PredictorV2
 
 face_contour_point_index = [
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
@@ -19,52 +19,26 @@ mouth_outer_point_index = [84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 84]
 mouth_inter_point_index = [96, 97, 98, 99, 100, 101, 102, 103, 96]
 
 
-@PREDICTORS.register_module()
-class FaceKeypointsPredictor(PredictorV2):
-    """Predict pipeline for face keypoint
+class FaceKptsOutputProcessor(OutputProcessor):
+    """Process the output of face keypoints models.
+
     Args:
-        model_path (str): Path of model path
-        config_file (str): config file path for model and processor to init. Defaults to None.
-        batch_size (int): batch size for forward.
-        device (str): Support 'cuda' or 'cpu', if is None, detect device automatically.
-        save_results (bool): Whether to save predict results.
-        save_path (str): File path for saving results, only valid when `save_results` is True.
-        pipelines (list[dict]): Data pipeline configs.
+        input_size (int): Target image size.
     """
 
-    def __init__(self,
-                 model_path,
-                 config_file,
-                 batch_size=1,
-                 device=None,
-                 save_results=False,
-                 save_path=None,
-                 pipelines=None):
-        super(FaceKeypointsPredictor, self).__init__(
-            model_path,
-            config_file,
-            batch_size=batch_size,
-            device=device,
-            save_results=save_results,
-            save_path=save_path,
-            pipelines=pipelines)
+    def __init__(self, input_size, point_number):
+        self.input_size = input_size
+        self.point_number = point_number
 
-        self.input_size = self.cfg.IMAGE_SIZE
-        self.point_number = self.cfg.POINT_NUMBER
-
-    def preprocess(self, inputs, *args, **kwargs):
-        batch_outputs = super().preprocess(inputs, *args, **kwargs)
-        self.img_metas = batch_outputs['img_metas']
-        return batch_outputs
-
-    def postprocess(self, inputs, *args, **kwargs):
+    def __call__(self, inputs):
         results = []
 
+        img_metas = inputs['img_metas']
         points = inputs['point'].cpu().numpy()
         poses = inputs['pose'].cpu().numpy()
 
         for idx, point in enumerate(points):
-            h, w, c = self.img_metas[idx]['img_shape']
+            h, w, c = img_metas[idx]['img_shape']
             scale_h = h / self.input_size
             scale_w = w / self.input_size
 
@@ -76,6 +50,57 @@ class FaceKeypointsPredictor(PredictorV2):
             results.append({'point': point, 'pose': poses[idx]})
 
         return results
+
+
+@PREDICTORS.register_module()
+class FaceKeypointsPredictor(PredictorV2):
+    """Predict pipeline for face keypoint
+    Args:
+        model_path (str): Path of model path
+        config_file (str): config file path for model and processor to init. Defaults to None.
+        batch_size (int): batch size for forward.
+        device (str): Support 'cuda' or 'cpu', if is None, detect device automatically.
+        save_results (bool): Whether to save predict results.
+        save_path (str): File path for saving results, only valid when `save_results` is True.
+        pipelines (list[dict]): Data pipeline configs.
+        num_parallel (int): Number of processes to process inputs.
+        mode (str): The image mode into the model.
+    """
+
+    def __init__(
+        self,
+        model_path,
+        config_file,
+        batch_size=1,
+        device=None,
+        save_results=False,
+        save_path=None,
+        pipelines=None,
+        num_parallel=8,
+        mode='BGR',
+    ):
+        super(FaceKeypointsPredictor, self).__init__(
+            model_path,
+            config_file,
+            batch_size=batch_size,
+            device=device,
+            save_results=save_results,
+            save_path=save_path,
+            pipelines=pipelines,
+            num_parallel=num_parallel,
+            mode=mode)
+
+        self.input_size = self.cfg.IMAGE_SIZE
+        self.point_number = self.cfg.POINT_NUMBER
+
+    def model_forward(self, inputs):
+        outputs = super().model_forward(inputs)
+        outputs['img_metas'] = inputs['img_metas']
+        return outputs
+
+    def get_output_processor(self):
+        return FaceKptsOutputProcessor(
+            input_size=self.input_size, point_number=self.point_number)
 
     def show_result(self, img, points, scale=4.0, save_path=None):
         """Draw `result` over `img`.

--- a/easycv/predictors/hand_keypoints_predictor.py
+++ b/easycv/predictors/hand_keypoints_predictor.py
@@ -32,7 +32,7 @@ class HandkptsInputProcessor(InputProcessor):
             cfg,
             pipelines=pipelines,
             batch_size=batch_size,
-            num_parallel=1,
+            threads=1,
             mode=mode)
 
     def _load_input(self, input):
@@ -152,7 +152,7 @@ class HandKeypointsPredictor(PredictorV2):
         save_results (bool): Whether to save predict results.
         save_path (str): File path for saving results, only valid when `save_results` is True.
         pipelines (list[dict]): Data pipeline configs.
-        num_parallel (int): Number of processes to process inputs.
+        input_processor_threads (int): Number of processes to process inputs.
         mode (str): The image mode into the model.
     """
 
@@ -179,7 +179,7 @@ class HandKeypointsPredictor(PredictorV2):
             save_results=save_results,
             save_path=save_path,
             pipelines=pipelines,
-            num_parallel=1,
+            input_processor_threads=1,
             mode=mode,
             *args,
             **kwargs)

--- a/easycv/predictors/ocr.py
+++ b/easycv/predictors/ocr.py
@@ -5,17 +5,9 @@ import os
 
 import cv2
 import numpy as np
-import torch
 from PIL import Image, ImageDraw, ImageFont
-from torchvision.transforms import Compose
 
-from easycv.datasets.registry import PIPELINES
-from easycv.file import io
-from easycv.models import build_model
 from easycv.predictors.builder import PREDICTORS
-from easycv.predictors.interface import PredictorInterface
-from easycv.utils.checkpoint import load_checkpoint
-from easycv.utils.registry import build_from_cfg
 from .base import PredictorV2
 
 
@@ -30,6 +22,8 @@ class OCRDetPredictor(PredictorV2):
                  save_results=False,
                  save_path=None,
                  pipelines=None,
+                 num_parallel=8,
+                 mode='BGR',
                  *args,
                  **kwargs):
 
@@ -41,6 +35,8 @@ class OCRDetPredictor(PredictorV2):
             save_results=save_results,
             save_path=save_path,
             pipelines=pipelines,
+            num_parallel=num_parallel,
+            mode=mode,
             *args,
             **kwargs)
 
@@ -63,6 +59,8 @@ class OCRRecPredictor(PredictorV2):
                  save_results=False,
                  save_path=None,
                  pipelines=None,
+                 num_parallel=8,
+                 mode='BGR',
                  *args,
                  **kwargs):
 
@@ -74,6 +72,8 @@ class OCRRecPredictor(PredictorV2):
             save_results=save_results,
             save_path=save_path,
             pipelines=pipelines,
+            num_parallel=num_parallel,
+            mode=mode,
             *args,
             **kwargs)
 
@@ -89,6 +89,8 @@ class OCRClsPredictor(PredictorV2):
                  save_results=False,
                  save_path=None,
                  pipelines=None,
+                 num_parallel=8,
+                 mode='BGR',
                  *args,
                  **kwargs):
 
@@ -100,6 +102,8 @@ class OCRClsPredictor(PredictorV2):
             save_results=save_results,
             save_path=save_path,
             pipelines=pipelines,
+            num_parallel=num_parallel,
+            mode=mode,
             *args,
             **kwargs)
 

--- a/easycv/predictors/ocr.py
+++ b/easycv/predictors/ocr.py
@@ -22,7 +22,7 @@ class OCRDetPredictor(PredictorV2):
                  save_results=False,
                  save_path=None,
                  pipelines=None,
-                 num_parallel=8,
+                 input_processor_threads=8,
                  mode='BGR',
                  *args,
                  **kwargs):
@@ -35,7 +35,7 @@ class OCRDetPredictor(PredictorV2):
             save_results=save_results,
             save_path=save_path,
             pipelines=pipelines,
-            num_parallel=num_parallel,
+            input_processor_threads=input_processor_threads,
             mode=mode,
             *args,
             **kwargs)
@@ -59,7 +59,7 @@ class OCRRecPredictor(PredictorV2):
                  save_results=False,
                  save_path=None,
                  pipelines=None,
-                 num_parallel=8,
+                 input_processor_threads=8,
                  mode='BGR',
                  *args,
                  **kwargs):
@@ -72,7 +72,7 @@ class OCRRecPredictor(PredictorV2):
             save_results=save_results,
             save_path=save_path,
             pipelines=pipelines,
-            num_parallel=num_parallel,
+            input_processor_threads=input_processor_threads,
             mode=mode,
             *args,
             **kwargs)
@@ -89,7 +89,7 @@ class OCRClsPredictor(PredictorV2):
                  save_results=False,
                  save_path=None,
                  pipelines=None,
-                 num_parallel=8,
+                 input_processor_threads=8,
                  mode='BGR',
                  *args,
                  **kwargs):
@@ -102,7 +102,7 @@ class OCRClsPredictor(PredictorV2):
             save_results=save_results,
             save_path=save_path,
             pipelines=pipelines,
-            num_parallel=num_parallel,
+            input_processor_threads=input_processor_threads,
             mode=mode,
             *args,
             **kwargs)

--- a/easycv/predictors/segmentation.py
+++ b/easycv/predictors/segmentation.py
@@ -23,7 +23,7 @@ class SegmentationPredictor(PredictorV2):
         save_results (bool): Whether to save predict results.
         save_path (str): File path for saving results, only valid when `save_results` is True.
         pipelines (list[dict]): Data pipeline configs.
-        num_parallel (int): Number of processes to process inputs.
+        input_processor_threads (int): Number of processes to process inputs.
         mode (str): The image mode into the model.
     """
 
@@ -35,7 +35,7 @@ class SegmentationPredictor(PredictorV2):
                  save_results=False,
                  save_path=None,
                  pipelines=None,
-                 num_parallel=8,
+                 input_processor_threads=8,
                  mode='BGR',
                  *args,
                  **kwargs):
@@ -48,7 +48,7 @@ class SegmentationPredictor(PredictorV2):
             save_results=save_results,
             save_path=save_path,
             pipelines=pipelines,
-            num_parallel=num_parallel,
+            input_processor_threads=input_processor_threads,
             mode=mode,
             *args,
             **kwargs)
@@ -185,7 +185,7 @@ class Mask2formerPredictor(SegmentationPredictor):
         save_results (bool): Whether to save predict results.
         save_path (str): File path for saving results, only valid when `save_results` is True.
         pipelines (list[dict]): Data pipeline configs.
-        num_parallel (int): Number of processes to process inputs.
+        input_processor_threads (int): Number of processes to process inputs.
         mode (str): The image mode into the model.
     """
 
@@ -198,7 +198,7 @@ class Mask2formerPredictor(SegmentationPredictor):
                  save_path=None,
                  pipelines=None,
                  task_mode='panoptic',
-                 num_parallel=8,
+                 input_processor_threads=8,
                  mode='BGR',
                  *args,
                  **kwargs):
@@ -210,7 +210,7 @@ class Mask2formerPredictor(SegmentationPredictor):
             save_results=save_results,
             save_path=save_path,
             pipelines=pipelines,
-            num_parallel=num_parallel,
+            input_processor_threads=input_processor_threads,
             mode=mode,
             *args,
             **kwargs)

--- a/easycv/predictors/segmentation.py
+++ b/easycv/predictors/segmentation.py
@@ -8,7 +8,7 @@ from matplotlib.patches import Polygon
 
 from easycv.core.visualization.image import imshow_bboxes
 from easycv.predictors.builder import PREDICTORS
-from .base import PredictorV2
+from .base import OutputProcessor, PredictorV2
 
 
 @PREDICTORS.register_module()
@@ -23,6 +23,8 @@ class SegmentationPredictor(PredictorV2):
         save_results (bool): Whether to save predict results.
         save_path (str): File path for saving results, only valid when `save_results` is True.
         pipelines (list[dict]): Data pipeline configs.
+        num_parallel (int): Number of processes to process inputs.
+        mode (str): The image mode into the model.
     """
 
     def __init__(self,
@@ -33,6 +35,8 @@ class SegmentationPredictor(PredictorV2):
                  save_results=False,
                  save_path=None,
                  pipelines=None,
+                 num_parallel=8,
+                 mode='BGR',
                  *args,
                  **kwargs):
 
@@ -44,6 +48,8 @@ class SegmentationPredictor(PredictorV2):
             save_results=save_results,
             save_path=save_path,
             pipelines=pipelines,
+            num_parallel=num_parallel,
+            mode=mode,
             *args,
             **kwargs)
 
@@ -126,64 +132,31 @@ class SegmentationPredictor(PredictorV2):
             return img
 
 
-@PREDICTORS.register_module()
-class Mask2formerPredictor(SegmentationPredictor):
-    """Predictor for Mask2former.
+class Mask2formerOutputProcessor(OutputProcessor):
+    """Process the output of Mask2former.
 
     Args:
-        model_path (str): Path of model path.
-        config_file (Optinal[str]): config file path for model and processor to init. Defaults to None.
-        batch_size (int): batch size for forward.
-        device (str): Support 'cuda' or 'cpu', if is None, detect device automatically.
-        save_results (bool): Whether to save predict results.
-        save_path (str): File path for saving results, only valid when `save_results` is True.
-        pipelines (list[dict]): Data pipeline configs.
+        task_mode (str): Support task in ['panoptic', 'instance', 'semantic'].
+        classes (list): Classes name list.
     """
 
-    def __init__(self,
-                 model_path,
-                 config_file=None,
-                 batch_size=1,
-                 device=None,
-                 save_results=False,
-                 save_path=None,
-                 pipelines=None,
-                 task_mode='panoptic',
-                 *args,
-                 **kwargs):
-        super(Mask2formerPredictor, self).__init__(
-            model_path,
-            config_file,
-            batch_size=batch_size,
-            device=device,
-            save_results=save_results,
-            save_path=save_path,
-            pipelines=pipelines,
-            *args,
-            **kwargs)
+    def __init__(self, task_mode, classes):
+        super(Mask2formerOutputProcessor, self).__init__()
         self.task_mode = task_mode
-        self.class_name = self.cfg.CLASSES
-        self.PALETTE = self.cfg.PALETTE
+        self.classes = classes
 
-    def forward(self, inputs):
-        """Model forward.
-        """
-        with torch.no_grad():
-            outputs = self.model.forward(**inputs, mode='test', encode=False)
-        return outputs
-
-    def postprocess_single(self, inputs, *args, **kwargs):
+    def process_single(self, inputs):
         output = {}
         if self.task_mode == 'panoptic':
             pan_results = inputs['pan_results']
             # keep objects ahead
             ids = np.unique(pan_results)[::-1]
-            legal_indices = ids != len(self.CLASSES)  # for VOID label
+            legal_indices = ids != len(self.classes)  # for VOID label
             ids = ids[legal_indices]
             labels = np.array([id % 1000 for id in ids], dtype=np.int64)
             segms = (pan_results[None] == ids[:, None, None])
             masks = [it.astype(np.int) for it in segms]
-            labels_txt = np.array(self.CLASSES)[labels].tolist()
+            labels_txt = np.array(self.classes)[labels].tolist()
 
             output['masks'] = masks
             output['labels'] = labels_txt
@@ -198,6 +171,62 @@ class Mask2formerPredictor(SegmentationPredictor):
         else:
             raise ValueError(f'Not support model {self.task_mode}')
         return output
+
+
+@PREDICTORS.register_module()
+class Mask2formerPredictor(SegmentationPredictor):
+    """Predictor for Mask2former.
+
+    Args:
+        model_path (str): Path of model path.
+        config_file (Optinal[str]): config file path for model and processor to init. Defaults to None.
+        batch_size (int): batch size for forward.
+        device (str): Support 'cuda' or 'cpu', if is None, detect device automatically.
+        save_results (bool): Whether to save predict results.
+        save_path (str): File path for saving results, only valid when `save_results` is True.
+        pipelines (list[dict]): Data pipeline configs.
+        num_parallel (int): Number of processes to process inputs.
+        mode (str): The image mode into the model.
+    """
+
+    def __init__(self,
+                 model_path,
+                 config_file=None,
+                 batch_size=1,
+                 device=None,
+                 save_results=False,
+                 save_path=None,
+                 pipelines=None,
+                 task_mode='panoptic',
+                 num_parallel=8,
+                 mode='BGR',
+                 *args,
+                 **kwargs):
+        super(Mask2formerPredictor, self).__init__(
+            model_path,
+            config_file,
+            batch_size=batch_size,
+            device=device,
+            save_results=save_results,
+            save_path=save_path,
+            pipelines=pipelines,
+            num_parallel=num_parallel,
+            mode=mode,
+            *args,
+            **kwargs)
+        self.task_mode = task_mode
+        self.class_name = self.cfg.CLASSES
+        self.PALETTE = self.cfg.PALETTE
+
+    def get_output_processor(self):
+        return Mask2formerOutputProcessor(self.task_mode, self.CLASSES)
+
+    def model_forward(self, inputs):
+        """Model forward.
+        """
+        with torch.no_grad():
+            outputs = self.model.forward(**inputs, mode='test', encode=False)
+        return outputs
 
     def show_panoptic(self, img, masks, labels):
         palette = np.asarray(self.cfg.PALETTE)

--- a/easycv/predictors/video_classifier.py
+++ b/easycv/predictors/video_classifier.py
@@ -1,80 +1,34 @@
 # Copyright (c) Alibaba, Inc. and its affiliates.
-import math
 
 import numpy as np
 import torch
-from PIL import Image, ImageFile
 
 from easycv.datasets.registry import PIPELINES
 from easycv.file import io
-from easycv.framework.errors import ValueError
 from easycv.models.builder import build_model
-from easycv.utils.misc import deprecated
 from easycv.utils.mmlab_utils import (dynamic_adapt_for_mmlab,
                                       remove_adapt_for_mmlab)
 from easycv.utils.registry import build_from_cfg
-from .base import Predictor, PredictorV2
+from .base import InputProcessor, OutputProcessor, PredictorV2
 from .builder import PREDICTORS
 
 
-@PREDICTORS.register_module()
-class VideoClassificationPredictor(PredictorV2):
-    """Predictor for classification.
-    Args:
-        model_path (str): Path of model path.
-        config_file (Optinal[str]): config file path for model and processor to init. Defaults to None.
-        batch_size (int): batch size for forward.
-        device (str): Support 'cuda' or 'cpu', if is None, detect device automatically.
-        save_results (bool): Whether to save predict results.
-        save_path (str): File path for saving results, only valid when `save_results` is True.
-        pipelines (list[dict]): Data pipeline configs.
-        topk (int): Return top-k results. Default: 1.
-        pil_input (bool): Whether use PIL image. If processor need PIL input, set true, default false.
-        label_map_path (str): File path of saving labels list.
-    """
+class VideoClsInputProcessor(InputProcessor):
 
     def __init__(self,
-                 model_path,
-                 config_file=None,
-                 batch_size=1,
-                 device=None,
-                 save_results=False,
-                 save_path=None,
+                 cfg,
                  pipelines=None,
-                 multi_class=False,
                  with_text=False,
-                 label_map_path=None,
-                 topk=1,
-                 *args,
-                 **kwargs):
-        super(VideoClassificationPredictor, self).__init__(
-            model_path,
-            config_file=config_file,
-            batch_size=batch_size,
-            device=device,
-            save_results=save_results,
-            save_path=save_path,
-            pipelines=pipelines,
-            *args,
-            **kwargs)
-        self.topk = topk
-        self.multi_class = multi_class
+                 batch_size=1,
+                 num_parallel=8,
+                 mode='RGB'):
         self.with_text = with_text
-
-        if label_map_path is None:
-            if 'CLASSES' in self.cfg:
-                class_list = self.cfg.get('CLASSES', [])
-            elif 'class_list' in self.cfg:
-                class_list = self.cfg.get('class_list', [])
-            elif 'num_classes' in self.cfg:
-                class_list = list(range(self.cfg.get('num_classes', 0)))
-                class_list = [str(i) for i in class_list]
-            else:
-                class_list = []
-        else:
-            with io.open(label_map_path, 'r') as f:
-                class_list = f.readlines()
-        self.label_map = [i.strip() for i in class_list]
+        super().__init__(
+            cfg,
+            pipelines=pipelines,
+            batch_size=batch_size,
+            num_parallel=num_parallel,
+            mode=mode)
 
     def _load_input(self, input):
         """Load image from file or numpy or PIL object.
@@ -93,7 +47,7 @@ class VideoClassificationPredictor(PredictorV2):
         if self.with_text and 'text' not in result:
             result['text'] = ''
         result['start_index'] = 0
-        result['modality'] = 'RGB'
+        result['modality'] = self.mode
 
         return result
 
@@ -121,20 +75,15 @@ class VideoClassificationPredictor(PredictorV2):
         processor = Compose(pipelines)
         return processor
 
-    def _build_model(self):
-        # Use mmdet model
-        dynamic_adapt_for_mmlab(self.cfg)
-        if 'vison_pretrained' in self.cfg.model:
-            self.cfg.model.vison_pretrained = None
-        if 'text_pretrained' in self.cfg.model:
-            self.cfg.model.text_pretrained = None
 
-        model = build_model(self.cfg.model)
-        # remove adapt for mmdet to avoid conflict using mmdet models
-        remove_adapt_for_mmlab(self.cfg)
-        return model
+class VideoClsOutputProcessor(OutputProcessor):
 
-    def postprocess(self, inputs, *args, **kwargs):
+    def __init__(self, label_map, topk=1):
+        super().__init__()
+        self.label_map = label_map
+        self.topk = topk
+
+    def __call__(self, inputs):
         """Return top-k results."""
         output_prob = inputs['prob'].data.cpu()
         topk_class = torch.topk(output_prob, self.topk).indices.numpy()
@@ -156,3 +105,94 @@ class VideoClassificationPredictor(PredictorV2):
 
             batch_results.append(result)
         return batch_results
+
+
+@PREDICTORS.register_module()
+class VideoClassificationPredictor(PredictorV2):
+    """Predictor for classification.
+    Args:
+        model_path (str): Path of model path.
+        config_file (Optinal[str]): config file path for model and processor to init. Defaults to None.
+        batch_size (int): batch size for forward.
+        device (str): Support 'cuda' or 'cpu', if is None, detect device automatically.
+        save_results (bool): Whether to save predict results.
+        save_path (str): File path for saving results, only valid when `save_results` is True.
+        pipelines (list[dict]): Data pipeline configs.
+        topk (int): Return top-k results. Default: 1.
+        pil_input (bool): Whether use PIL image. If processor need PIL input, set true, default false.
+        label_map_path (str): File path of saving labels list.
+        num_parallel (int): Number of processes to process inputs.
+        mode (str): The image mode into the model.
+    """
+
+    def __init__(self,
+                 model_path,
+                 config_file=None,
+                 batch_size=1,
+                 device=None,
+                 save_results=False,
+                 save_path=None,
+                 pipelines=None,
+                 multi_class=False,
+                 with_text=False,
+                 label_map_path=None,
+                 topk=1,
+                 num_parallel=8,
+                 mode='RGB',
+                 *args,
+                 **kwargs):
+        super(VideoClassificationPredictor, self).__init__(
+            model_path,
+            config_file=config_file,
+            batch_size=batch_size,
+            device=device,
+            save_results=save_results,
+            save_path=save_path,
+            pipelines=pipelines,
+            num_parallel=num_parallel,
+            mode=mode,
+            *args,
+            **kwargs)
+        self.topk = topk
+        self.multi_class = multi_class
+        self.with_text = with_text
+
+        if label_map_path is None:
+            if 'CLASSES' in self.cfg:
+                class_list = self.cfg.get('CLASSES', [])
+            elif 'class_list' in self.cfg:
+                class_list = self.cfg.get('class_list', [])
+            elif 'num_classes' in self.cfg:
+                class_list = list(range(self.cfg.get('num_classes', 0)))
+                class_list = [str(i) for i in class_list]
+            else:
+                class_list = []
+        else:
+            with io.open(label_map_path, 'r') as f:
+                class_list = f.readlines()
+        self.label_map = [i.strip() for i in class_list]
+
+    def _build_model(self):
+        # Use mmdet model
+        dynamic_adapt_for_mmlab(self.cfg)
+        if 'vison_pretrained' in self.cfg.model:
+            self.cfg.model.vison_pretrained = None
+        if 'text_pretrained' in self.cfg.model:
+            self.cfg.model.text_pretrained = None
+
+        model = build_model(self.cfg.model)
+        # remove adapt for mmdet to avoid conflict using mmdet models
+        remove_adapt_for_mmlab(self.cfg)
+        return model
+
+    def get_input_processor(self):
+        return VideoClsInputProcessor(
+            self.cfg,
+            pipelines=self.pipelines,
+            with_text=self.with_text,
+            batch_size=self.batch_size,
+            num_parallel=self.num_parallel,
+            mode=self.mode)
+
+    def get_output_processor(self):
+        return VideoClsOutputProcessor(self.label_map, self.topk)

--- a/easycv/predictors/video_classifier.py
+++ b/easycv/predictors/video_classifier.py
@@ -20,14 +20,14 @@ class VideoClsInputProcessor(InputProcessor):
                  pipelines=None,
                  with_text=False,
                  batch_size=1,
-                 num_parallel=8,
+                 threads=8,
                  mode='RGB'):
         self.with_text = with_text
         super().__init__(
             cfg,
             pipelines=pipelines,
             batch_size=batch_size,
-            num_parallel=num_parallel,
+            threads=threads,
             mode=mode)
 
     def _load_input(self, input):
@@ -121,7 +121,7 @@ class VideoClassificationPredictor(PredictorV2):
         topk (int): Return top-k results. Default: 1.
         pil_input (bool): Whether use PIL image. If processor need PIL input, set true, default false.
         label_map_path (str): File path of saving labels list.
-        num_parallel (int): Number of processes to process inputs.
+        input_processor_threads (int): Number of processes to process inputs.
         mode (str): The image mode into the model.
     """
 
@@ -137,7 +137,7 @@ class VideoClassificationPredictor(PredictorV2):
                  with_text=False,
                  label_map_path=None,
                  topk=1,
-                 num_parallel=8,
+                 input_processor_threads=8,
                  mode='RGB',
                  *args,
                  **kwargs):
@@ -149,7 +149,7 @@ class VideoClassificationPredictor(PredictorV2):
             save_results=save_results,
             save_path=save_path,
             pipelines=pipelines,
-            num_parallel=num_parallel,
+            input_processor_threads=input_processor_threads,
             mode=mode,
             *args,
             **kwargs)
@@ -191,7 +191,7 @@ class VideoClassificationPredictor(PredictorV2):
             pipelines=self.pipelines,
             with_text=self.with_text,
             batch_size=self.batch_size,
-            num_parallel=self.num_parallel,
+            threads=self.input_processor_threads,
             mode=self.mode)
 
     def get_output_processor(self):

--- a/easycv/predictors/wholebody_keypoints_predictor.py
+++ b/easycv/predictors/wholebody_keypoints_predictor.py
@@ -39,7 +39,7 @@ class WholeBodyKptsInputProcessor(InputProcessor):
             cfg,
             pipelines=pipelines,
             batch_size=batch_size,
-            num_parallel=1,
+            threads=1,
             mode=mode)
 
     def process_detection_results(self, det_results, cat_id=0):
@@ -217,7 +217,7 @@ class WholeBodyKeypointsPredictor(PredictorV2):
             device=device,
             save_results=save_results,
             save_path=save_path,
-            num_parallel=1,
+            input_processor_threads=1,
             mode=mode,
             *args,
             **kwargs)

--- a/tests/predictors/test_detector.py
+++ b/tests/predictors/test_detector.py
@@ -53,14 +53,14 @@ class YoloXPredictorTest(unittest.TestCase):
                          inputs,
                          num_samples,
                          batch_size,
-                         num_parallel=8):
+                         input_processor_threads=8):
         assert isinstance(inputs, list) and len(inputs) == 1
 
         predictor = YoloXPredictor(
             model_path=model_path,
             score_thresh=0.5,
             batch_size=batch_size,
-            num_parallel=num_parallel)
+            input_processor_threads=input_processor_threads)
         outputs = predictor(inputs * num_samples)
 
         self.assertEqual(len(outputs), num_samples)
@@ -93,7 +93,10 @@ class YoloXPredictorTest(unittest.TestCase):
     def test_batch_jit_pre_trt(self):
         jit_path = PRETRAINED_MODEL_YOLOXS_PRE_NOTRT_JIT_B2
         self._base_test_batch(
-            jit_path, [self.img], num_samples=4, batch_size=2, num_parallel=1)
+            jit_path, [self.img],
+            num_samples=4,
+            batch_size=2,
+            input_processor_threads=1)
 
     def test_single_raw_TorchYoloXPredictor(self):
         detection_model_path = PRETRAINED_MODEL_YOLOXS_EXPORT

--- a/tests/predictors/test_detector.py
+++ b/tests/predictors/test_detector.py
@@ -48,11 +48,19 @@ class YoloXPredictorTest(unittest.TestCase):
         output = outputs[0]
         self._assert_results(output)
 
-    def _base_test_batch(self, model_path, inputs, num_samples, batch_size):
+    def _base_test_batch(self,
+                         model_path,
+                         inputs,
+                         num_samples,
+                         batch_size,
+                         num_parallel=8):
         assert isinstance(inputs, list) and len(inputs) == 1
 
         predictor = YoloXPredictor(
-            model_path=model_path, score_thresh=0.5, batch_size=batch_size)
+            model_path=model_path,
+            score_thresh=0.5,
+            batch_size=batch_size,
+            num_parallel=num_parallel)
         outputs = predictor(inputs * num_samples)
 
         self.assertEqual(len(outputs), num_samples)
@@ -85,7 +93,7 @@ class YoloXPredictorTest(unittest.TestCase):
     def test_batch_jit_pre_trt(self):
         jit_path = PRETRAINED_MODEL_YOLOXS_PRE_NOTRT_JIT_B2
         self._base_test_batch(
-            jit_path, [self.img], num_samples=4, batch_size=2)
+            jit_path, [self.img], num_samples=4, batch_size=2, num_parallel=1)
 
     def test_single_raw_TorchYoloXPredictor(self):
         detection_model_path = PRETRAINED_MODEL_YOLOXS_EXPORT

--- a/tests/predictors/test_face_keypoints_predictor.py
+++ b/tests/predictors/test_face_keypoints_predictor.py
@@ -3,7 +3,7 @@
 import unittest
 
 import cv2
-from ut_config import PRETRAINED_MODEL_FACE_2D_KEYPOINTS
+from tests.ut_config import PRETRAINED_MODEL_FACE_2D_KEYPOINTS
 
 from easycv.predictors.face_keypoints_predictor import FaceKeypointsPredictor
 

--- a/tests/predictors/test_hand_keypoints_predictor.py
+++ b/tests/predictors/test_hand_keypoints_predictor.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from ut_config import PRETRAINED_MODEL_HAND_KEYPOINTS
+from tests.ut_config import PRETRAINED_MODEL_HAND_KEYPOINTS
 
 from easycv.predictors.hand_keypoints_predictor import HandKeypointsPredictor
 from easycv.utils.config_tools import mmcv_config_fromfile

--- a/tests/predictors/test_segmentation.py
+++ b/tests/predictors/test_segmentation.py
@@ -105,10 +105,11 @@ class SegmentationPredictorTest(unittest.TestCase):
         total_samples = 3
         outputs = predict_pipeline(
             [self.img_path] * total_samples, keep_inputs=False)
-        self.assertEqual(outputs, [])
 
         with open(tmp_path, 'rb') as f:
             results = pickle.loads(f.read())
+
+        self.assertEqual(len(results), total_samples)
 
         for res in results:
             self.assertNotIn('inputs', res)

--- a/tests/predictors/test_wholebody_keypoints_predictor.py
+++ b/tests/predictors/test_wholebody_keypoints_predictor.py
@@ -2,8 +2,8 @@
 
 import unittest
 
-from ut_config import (PRETRAINED_MODEL_WHOLEBODY,
-                       PRETRAINED_MODEL_WHOLEBODY_DETECTION)
+from tests.ut_config import (PRETRAINED_MODEL_WHOLEBODY,
+                             PRETRAINED_MODEL_WHOLEBODY_DETECTION)
 
 from easycv.predictors.wholebody_keypoints_predictor import \
     WholeBodyKeypointsPredictor


### PR DESCRIPTION
Support multi processes for predictor.

env：torch1.8.0, cuda102, v100, cpu 96 core

> 需要在子进程中设置``torch.set_num_threads(1)``解决pytorch多进程卡死的问题。
问题描述参考：[[ToTensor deadlock in subprocess · Issue #7068 · pytorch/vision · GitHub](https://github.com/pytorch/vision/issues/7068)](https://github.com/pytorch/vision/issues/7068) 
torch dataloder多进程时也设置了num_threads=1，参考：torch.utilss.data._utils.worker._worker_loop

<img width="839" alt="image" src="https://user-images.githubusercontent.com/30484308/215518815-7d3c3b41-3be0-4959-89d1-ba2b2e10c941.png">
<img width="841" alt="image" src="https://user-images.githubusercontent.com/30484308/215518930-cab7a002-51ae-4a3e-9732-2bad3e4af23c.png">
